### PR TITLE
Remove an unused variable from scanner.c

### DIFF
--- a/scanner.c
+++ b/scanner.c
@@ -1186,11 +1186,9 @@ yaml_parser_increase_flow_level(yaml_parser_t *parser)
 static int
 yaml_parser_decrease_flow_level(yaml_parser_t *parser)
 {
-    yaml_simple_key_t dummy_key;    /* Used to eliminate a compiler warning. */
-
     if (parser->flow_level) {
         parser->flow_level --;
-        dummy_key = POP(parser, parser->simple_keys);
+        (void*)POP(parser, parser->simple_keys);
     }
 
     return 1;


### PR DESCRIPTION
Causes `-Wunused-but-set-variable` to pass;